### PR TITLE
Set max audio duration for audio tasks

### DIFF
--- a/evals/elsuite/audio/eval.py
+++ b/evals/elsuite/audio/eval.py
@@ -62,18 +62,18 @@ class AudioTask(evals.Eval):
         sampled = self.do_completion(prompt, **kwargs)
         return self.compute_metrics(sample, sampled)
 
-    def _keep_sample(self, sample, max_audio_duration: int):
+    def _keep_sample(self, sample):
         """
         Allows for applying additional filtering to samples before evaluation.
 
         Currently only filters out samples with audio longer than max_audio_duration.
         """
         audio_len = len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
-        return audio_len < max_audio_duration
+        return audio_len < self.max_audio_duration
 
     def run(self, recorder: RecorderBase):
         samples = self.load_dataset()
-        samples = [s for s in samples if self._keep_sample(samples, self.max_audio_duration)]
+        samples = [s for s in samples if self._keep_sample(samples)]
         self._recorder = recorder
         self.eval_all_samples(recorder, samples)
         return self.compute_corpus_metrics()
@@ -302,10 +302,10 @@ class SpokenTools(MatchAudioTask):
         )
         return list(ds)
 
-    def _keep_sample(self, sample, max_audio_duration: int):
+    def _keep_sample(self, sample):
         audio = sample["user_message_audios"][0]
         audio_len = len(audio["array"]) / audio["sampling_rate"]
-        return audio_len < max_audio_duration
+        return audio_len < self.max_audio_duration
 
     def build_prompt(self, sample: Sample, text_only: bool = False):
         # The FireFunction test data that we have doesn't have the right tool_call_ids, so

--- a/evals/elsuite/audio/eval.py
+++ b/evals/elsuite/audio/eval.py
@@ -63,8 +63,18 @@ class AudioTask(evals.Eval):
         sampled = self.do_completion(prompt, **kwargs)
         return self.compute_metrics(sample, sampled)
 
+    def _keep_sample(self, sample, max_audio_duration: int):
+        """
+        Allows for applying additional filtering to samples before evaluation.
+
+        Currently only filters out samples with audio longer than max_audio_duration.
+        """
+        audio_len = len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
+        return audio_len < max_audio_duration
+
     def run(self, recorder: RecorderBase):
         samples = self.load_dataset()
+        samples = [s for s in samples if self._keep_sample(samples, self.max_audio_duration)]
         self._recorder = recorder
         self.eval_all_samples(recorder, samples)
         return self.compute_corpus_metrics()
@@ -302,6 +312,11 @@ class SpokenTools(MatchAudioTask):
             "user_message_audios", [Audio(sampling_rate=DEFAULT_SAMPLE_RATE)]
         )
         return list(ds)
+
+    def _keep_sample(self, sample, max_audio_duration: int):
+        audio = sample["user_message_audios"][0]
+        audio_len = len(audio["array"]) / audio["sampling_rate"]
+        return audio_len < max_audio_duration
 
     def build_prompt(self, sample: Sample, text_only: bool = False):
         # The FireFunction test data that we have doesn't have the right tool_call_ids, so

--- a/evals/elsuite/audio/eval.py
+++ b/evals/elsuite/audio/eval.py
@@ -15,6 +15,7 @@ from evals.elsuite.audio.utils import (
     AUDIO_PLACEHOLDER,
     DEFAULT_SAMPLE_RATE,
     build_messages,
+    get_audio_duration,
     load_hf_dataset,
     make_audio_content,
     redact_audio_content,
@@ -68,8 +69,7 @@ class AudioTask(evals.Eval):
 
         Currently only filters out samples with audio longer than max_audio_duration.
         """
-        audio_len = len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
-        return audio_len < self.max_audio_duration
+        return get_audio_duration(sample["audio"]) < self.max_audio_duration
 
     def run(self, recorder: RecorderBase):
         samples = self.load_dataset()
@@ -303,9 +303,7 @@ class SpokenTools(MatchAudioTask):
         return list(ds)
 
     def _keep_sample(self, sample):
-        audio = sample["user_message_audios"][0]
-        audio_len = len(audio["array"]) / audio["sampling_rate"]
-        return audio_len < self.max_audio_duration
+        return get_audio_duration(sample["user_message_audios"][0]) < self.max_audio_duration
 
     def build_prompt(self, sample: Sample, text_only: bool = False):
         # The FireFunction test data that we have doesn't have the right tool_call_ids, so

--- a/evals/elsuite/audio/eval.py
+++ b/evals/elsuite/audio/eval.py
@@ -192,10 +192,7 @@ class Transcribe(MatchAudioTask):
             ]
         )
         output = jiwer.process_words(
-            expected,
-            sampled,
-            reference_transform=transform,
-            hypothesis_transform=transform,
+            expected, sampled, reference_transform=transform, hypothesis_transform=transform
         )
         return output.wer
 
@@ -227,10 +224,7 @@ class Translate(MatchAudioTask):
         match = score > 30
         if score is not None:
             evals.record.record_match(
-                match,
-                expected=expected,
-                sampled=sampled,
-                sacrebleu_sentence_score=score,
+                match, expected=expected, sampled=sampled, sacrebleu_sentence_score=score
             )
         return match
 

--- a/evals/elsuite/audio/eval.py
+++ b/evals/elsuite/audio/eval.py
@@ -1,4 +1,3 @@
-import dataclasses
 import json
 import logging
 import string
@@ -83,7 +82,6 @@ class AudioTask(evals.Eval):
         ds = load_hf_dataset(self.dataset, evals.eval._MAX_SAMPLES).cast_column(
             "audio", Audio(sampling_rate=DEFAULT_SAMPLE_RATE)
         )
-        ds = ds.filter(IsAudioLengthInRange(self.max_audio_duration))
         return list(ds)
 
     def get_completion_kwargs(self, sample: Sample):
@@ -105,15 +103,6 @@ class AudioTask(evals.Eval):
             logging.info(f"Error: {str(e)}")
             sampled = "ERROR: " + str(e)
         return sampled
-
-
-@dataclasses.dataclass
-class IsAudioLengthInRange:
-    max_duration_in_seconds: float
-
-    def __call__(self, sample):
-        audio_len = len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
-        return audio_len < self.max_duration_in_seconds
 
 
 class MatchAudioTask(AudioTask):

--- a/evals/solvers/providers/fixie/local_gpu_solver.py
+++ b/evals/solvers/providers/fixie/local_gpu_solver.py
@@ -78,7 +78,7 @@ class FixieGPUSolver(Solver):
 
         self.executor = BatchedProcessPoolExecutor(
             max_workers=max(1, num_gpus),
-            max_batch_size=max_batch_size,
+            max_batch_size=int(max_batch_size),
             initializer=solver_initializer,
             initargs=(rank_queue, num_gpus, model, extra_options),
             batch_worker_fn=solver_worker,


### PR DESCRIPTION
Since our model has a maximum audio length it can handle, any samples that are longer than that will cause us to raise an error.
This is particularly problematic since an issue with one sample can cause the whole batch to fail.

This PR filters the samples so that such samples will not be considered (not for audio nor transcript tasks).