### PR TITLE
works with latest websockets

### DIFF
--- a/evals/registry/solvers/realtime.yaml
+++ b/evals/registry/solvers/realtime.yaml
@@ -6,5 +6,5 @@ generation/realtime/gpt-4o-realtime:
     completion_fn_options:
       model: gpt-4o-realtime-preview-2024-10-01
       extra_options:
-        temperature: 1
+        temperature: 0
         max_tokens: 512


### PR DESCRIPTION
## Problem
- A websockets update broke our connection for Open AI evals. [See here for more details](https://websockets.readthedocs.io/en/stable/faq/client.html#how-do-i-set-http-headers)
- It also seems as though there may have been a bug in the logic for sending content, where content could be sent even if only the system message was received.

## Solution
- Changing `websockets.connect(url, extra_headers=...)` to `websockets.connect(url, additional_headers=...`) fixed the first error code being received.
- Fixed logic so a message is only sent when `content` is populated


## Testing

```oaieval generation/realtime/gpt-4o-realtime audio-bigbench --max_samples 10```

> [2025-01-31 19:10:00,090] [registry.py:282] Loading registry from /Users/keeganquigley/Documents/fixie/code/evals/evals/registry/evals
[2025-01-31 19:10:00,277] [registry.py:282] Loading registry from /Users/keeganquigley/.evals/evals
[2025-01-31 19:10:00,881] [registry.py:282] Loading registry from /Users/keeganquigley/Documents/fixie/code/evals/evals/registry/completion_fns
[2025-01-31 19:10:00,883] [registry.py:282] Loading registry from /Users/keeganquigley/.evals/completion_fns
[2025-01-31 19:10:00,883] [registry.py:282] Loading registry from /Users/keeganquigley/Documents/fixie/code/evals/evals/registry/solvers
[2025-01-31 19:10:00,939] [registry.py:282] Loading registry from /Users/keeganquigley/.evals/solvers
[2025-01-31 19:10:00,960] [oaieval.py:215] Run started: 250201001000PCNDCHO7
[2025-01-31 19:10:01,045] [utils.py:162] NumExpr defaulting to 14 threads.
[2025-01-31 19:10:01,144] [config.py:54] PyTorch version 2.6.0 available.
[2025-01-31 19:10:05,722] [eval.py:36] Evaluating 10 samples
[2025-01-31 19:10:05,723] [eval.py:144] Running in threaded mode with 10 threads!
100%|████████████████████████████████████| 10/10 [00:12<00:00,  1.23s/it]
[2025-01-31 19:10:18,026] [record.py:371] Final report: {'accuracy': 0.7}. Logged to /tmp/evallogs/250201001000PCNDCHO7_generation/realtime/gpt-4o-realtime_audio-bigbench.jsonl
[2025-01-31 19:10:18,026] [oaieval.py:233] Final report:
[2025-01-31 19:10:18,026] [oaieval.py:235] accuracy: 0.7
[2025-01-31 19:10:18,037] [record.py:360] Logged 20 rows of events to /tmp/evallogs/250201001000PCNDCHO7_generation/realtime/gpt-4o-realtime_audio-bigbench.jsonl: insert_time=3.429ms

It appears as though openai requests are now properly working, but it's possible I may have misunderstood the logic for sending messages.