### PR TITLE
Fix audio-bench-slue-p2-sqa5 naming

### DIFF
--- a/evals/registry/eval_sets/audio.yaml
+++ b/evals/registry/eval_sets/audio.yaml
@@ -17,7 +17,7 @@ audio-core:
     - audio-bench-cn-college-listen-mcq
     - audio-bench-dream-tts-mcq
     - audio-bench-public-sg-speech-qa
-    - audio-slue-p2-sqa5
+    - audio-bench-slue-p2-sqa5
     - audio-translate-covost-zh-CN_en
     - audio-translate-covost-ru_en
     - audio-translate-covost-es_en

--- a/evals/registry/eval_sets/audio.yaml
+++ b/evals/registry/eval_sets/audio.yaml
@@ -14,10 +14,10 @@ audio-core:
   evals:
     - audio-transcribe
     - audio-bigbench
-    - audio-bench-cn-college-listen-mcq
-    - audio-bench-dream-tts-mcq
-    - audio-bench-public-sg-speech-qa
-    - audio-bench-slue-p2-sqa5
+    - audiobench-cn-college-listen-mcq
+    - audiobench-dream-tts-mcq
+    - audiobench-public-sg-speech-qa
+    - audiobench-slue-p2-sqa5
     - audio-translate-covost-zh-CN_en
     - audio-translate-covost-ru_en
     - audio-translate-covost-es_en
@@ -67,10 +67,10 @@ audio-sqa:
   evals:
     - audio-sqa-web-questions
     - audio-bigbench
-    - audio-bench-cn-college-listen-mcq
-    - audio-bench-dream-tts-mcq
-    - audio-bench-public-sg-speech-qa
-    - audio-slue-p2-sqa5
+    - audiobench-cn-college-listen-mcq
+    - audiobench-dream-tts-mcq
+    - audiobench-public-sg-speech-qa
+    - audiobench-slue-p2-sqa5
 
 transcript-sqa:
   evals:

--- a/evals/registry/evals/audio_tasks.yaml
+++ b/evals/registry/evals/audio_tasks.yaml
@@ -159,10 +159,10 @@ audio-bench-public-sg-speech-qa.validation.v1:
     max_audio_duration: -1
     is_mcq: false 
 
-audio-slue-p2-sqa5: 
-  id: audio-slue-p2-sqa5.validation.v1
+audio-bench-slue-p2-sqa5: 
+  id: audio-bench-slue-p2-sqa5.validation.v1
   metrics: [accuracy]
-audio-slue-p2-sqa5.validation.v1:
+audio-bench-slue-p2-sqa5.validation.v1:
   class: evals.elsuite.audio.eval:AudioBenchTask
   args:
     dataset: hf://fixie-ai/slue_p2_sqa5_test?split=test

--- a/evals/registry/evals/audio_tasks.yaml
+++ b/evals/registry/evals/audio_tasks.yaml
@@ -126,10 +126,10 @@ audio-bigbench.validation.v1:
     eval_completion_fn: gpt-4o
     max_audio_duration: -1
 
-audio-bench-cn-college-listen-mcq:
-  id: audio-bench-cn-college-listen-mcq.validation.v1
+audiobench-cn-college-listen-mcq:
+  id: audiobench-cn-college-listen-mcq.validation.v1
   metrics: [accuracy]
-audio-bench-cn-college-listen-mcq.validation.v1:
+audiobench-cn-college-listen-mcq.validation.v1:
   class: evals.elsuite.audio.eval:AudioBenchTask
   args:
     dataset: hf://fixie-ai/cn_college_listen_mcq_test?split=test
@@ -137,10 +137,10 @@ audio-bench-cn-college-listen-mcq.validation.v1:
     max_audio_duration: -1
     is_mcq: true
 
-audio-bench-dream-tts-mcq: 
-  id: audio-bench-dream-tts-mcq.validation.v1
+audiobench-dream-tts-mcq: 
+  id: audiobench-dream-tts-mcq.validation.v1
   metrics: [accuracy]
-audio-bench-dream-tts-mcq.validation.v1:
+audiobench-dream-tts-mcq.validation.v1:
   class: evals.elsuite.audio.eval:AudioBenchTask
   args:
     dataset: hf://fixie-ai/dream_tts_mcq_test?split=test
@@ -148,10 +148,10 @@ audio-bench-dream-tts-mcq.validation.v1:
     max_audio_duration: -1
     is_mcq: true
 
-audio-bench-public-sg-speech-qa:
-  id: audio-bench-public-sg-speech-qa.validation.v1
+audiobench-public-sg-speech-qa:
+  id: audiobench-public-sg-speech-qa.validation.v1
   metrics: [accuracy]
-audio-bench-public-sg-speech-qa.validation.v1:
+audiobench-public-sg-speech-qa.validation.v1:
   class: evals.elsuite.audio.eval:AudioBenchTask
   args:
     dataset: hf://fixie-ai/public_sg_speech_qa_test?split=test
@@ -159,10 +159,10 @@ audio-bench-public-sg-speech-qa.validation.v1:
     max_audio_duration: -1
     is_mcq: false 
 
-audio-bench-slue-p2-sqa5: 
-  id: audio-bench-slue-p2-sqa5.validation.v1
+audiobench-slue-p2-sqa5: 
+  id: audiobench-slue-p2-sqa5.validation.v1
   metrics: [accuracy]
-audio-bench-slue-p2-sqa5.validation.v1:
+audiobench-slue-p2-sqa5.validation.v1:
   class: evals.elsuite.audio.eval:AudioBenchTask
   args:
     dataset: hf://fixie-ai/slue_p2_sqa5_test?split=test


### PR DESCRIPTION
Making audiobench naming more consistent with what we have in local evals. 