### PR TITLE
Reverting the hack for vllm for putting <|audio|> in the right place

### DIFF
--- a/evals/solvers/providers/fixie/fixie_solver.py
+++ b/evals/solvers/providers/fixie/fixie_solver.py
@@ -4,7 +4,7 @@ from evals.solvers.providers.openai.third_party_solver import ThirdPartySolver
 
 
 class FixieSolver(ThirdPartySolver):
-    AUDIO_PLACEHOLDER = "<|reserved_special_token_0|>"
+    AUDIO_PLACEHOLDER = "<|audio|>"
 
     def __init__(self, api_base: Optional[str] = None, **kwargs):
         super().__init__(api_base or "https://api.ultravox.ai/api/", "ULTRAVOX_API_KEY", **kwargs)


### PR DESCRIPTION
This PR should only be merged when we move Ultravox to the latest vllm version.

It's good to coordinate this change so our old code won't break.